### PR TITLE
Update cursor search to not jump to the next one

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -26,6 +26,9 @@ set scrolloff=5              " cursor stays this many lines from top and bottom 
 set hlsearch                 " highlight matches wehen searching
 set ignorecase               " case insensitive searching
 set showmatch                " show matching brackets and curly braces
+" cursor search doesn't jump to the next occurrence
+noremap * *``
+noremap # #``
 
 " Tabs and Panes
 set splitbelow               " open horizontal split panes below


### PR DESCRIPTION
This allows for highlighting of all occurences of the word under the
cursor instead of automatically jumping to the next or previous one.
Note that because of the rest of the vimrc, search is case insensitive
right now.