### PR TITLE
Include setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
-These are my dotfiles.  In order to put them into a git repository so I could access them wherever, I had to create hard links.
-So for every file in the home directory, I created a hard link to this directory using the `ln` command in terminal.
+# ReadMe
+
+This is a collection of things for my personal computer setup. As of right now, there's a setup script that installs things via the command line. It mostly leverages homebrew to manage everything.
+
+## Dotfiles
+There's also a collection dotfiles. They're here so I can  access them from wherever. In order to maintain this repo, I had to create hard links from the dotfiles in this folder to the actual locations the dotfiles belong.

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Setup script for a fresh Macbook pro
+
+USER=$(whoami)
+
+# checks if the executable exists
+function is_installed() {
+    echo -n "Checking if $1 is installed: "
+    if command -v "$1" >/dev/null 2>&1; then
+      echo "yep"
+      status=0
+    else
+      echo "nope"
+      status=1
+    fi
+    return $status
+}
+
+function install_homebrew() {
+    is_installed brew
+    status=$?
+    if ! [[ status ]]; then
+      /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+      (echo; echo 'eval "$(/usr/local/bin/brew shellenv)"') >> /Users/$USER/.zprofile
+      (echo; echo 'eval "$(/usr/local/bin/brew shellenv)"') >> /Users/$USER/.bash_profile
+    fi
+}
+
+function install_iterm() {
+    brew install --cask iterm2
+}
+
+function install_karabiner() {
+    # is_installed "/Library/Application Support/org.pqrs/Karabiner-Elements/bin/karabiner_cli" || brew install --cask karabiner-elements
+    brew install --cask karabiner-elements
+}
+
+function install_chrome() {
+    brew install --cask google-chrome
+}
+
+# sets bash as the default shell
+function set_bash() {
+    if [ $SHELL != "/bin/bash" ]; then
+        chsh -u $USER -s /bin/bash
+    fi
+}
+
+function install_spotify() {
+    brew install --cask spotify
+}
+
+function install_whatsapp() {
+    brew install --cask whatsapp
+}
+
+function install_slack() {
+    brew install --cask slack
+}
+
+set_bash
+install_homebrew
+install_iterm
+install_karabiner
+install_chrome
+install_whatsapp
+install_spotify
+install_slack


### PR DESCRIPTION
The setup script changes this from a dotfiles repo to a computer setup one in general. The setup script installs homebrew, which should install xcode command line tools and other dependencies, and then uses homebrew to install the applications I use most commonly. Dev setup to follow